### PR TITLE
chore(sync): initial setup of fake API file sync

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -1,0 +1,11 @@
+group:
+  repos: |
+    futureleadersupc/waw-frontend-vue
+    futureleadersupc/waw-frontend-angular
+  files:
+    - source: db.json
+      dest: server/db.json
+    - source: routes.json
+      dest: server/routes.json
+    - source: .github/workflows/sync.yml
+      dest: .github/workflows/sync.yml


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

Before you start, please make sure your issue is understandable and reproducible.
To make your issue readable make sure you use valid Markdown syntax.

https://guides.github.com/features/mastering-markdown/

-->

### What does it do

These changes will allow us to change the fake database file anywhere in our codebase while keeping it synced with other repositories.

### Usage

Change either the `db.json` or `routes.json` file and PRs will be opened in the other repositories automatically by @dalbitresb12-bot.

### Why is it needed

We'll be able to use `json-server` independently in each project, while keeping the fake database in sync.

### Related issue(s)/PR(s)

- Workflow implementation on futureleadersupc/waw-frontend-vue#22.
- Initial setup for Angular project on futureleadersupc/waw-frontend-angular#14.
